### PR TITLE
Add option for overriding UTC offset when formatting time for upcoming show(s)

### DIFF
--- a/css/base.less
+++ b/css/base.less
@@ -251,7 +251,8 @@ body {
         cursor: default;
     }
 
-    .checkbox-inline {
+    .checkbox-inline,
+    .select-one-inline {
         padding-left: 0;
         margin: 2px 0;
 

--- a/js/background-functions.js
+++ b/js/background-functions.js
@@ -91,6 +91,7 @@ var getScheduleCallback = function(site, data) {
     if (data.upcoming.length > 0) {
         var eventType,
             scheduleDate,
+            clockFormat = getClockFormat();
             liveShows = [];
 
         $.each(data.upcoming, function(key, val) {
@@ -124,9 +125,10 @@ var getScheduleCallback = function(site, data) {
             } else {
                 if (storage.get('24h-clock')) {
                     scheduleDate = '- ' + dt.calendar(null, {
-                        sameDay: '[Today at] H:mm',
-                        nextDay: '[Tomorrow at] H:mm',
-                        sameElse: 'H:mm'
+                        sameDay: '[Today at] '+clockFormat,
+                        nextDay: '[Tomorrow at] '+clockFormat,
+                        nextWeek: 'dddd ' +clockFormat,
+                        sameElse: clockFormat
                     });
                 }
                 else {
@@ -226,6 +228,14 @@ var scheduleRoutine = function() {
 
     return getScheduleDone.promise();
 };
+
+var getClockFormat = function(){
+
+    if(storage.get('24h-clock')){
+        return 'HH:mm';
+    }
+    return 'h:mm:ss a';
+}
 
 /**
  * Get UTC offset from storage, if set and a number. Otherwise return

--- a/js/background-functions.js
+++ b/js/background-functions.js
@@ -79,7 +79,7 @@ var getSchedule = function() {
     $.each(siteData.sites, function(key, site) {
         if (storage.get(site.upcomingSetting)) {
             getScheduleDone.push($.getJSON(site.dataUrl, function(data) {
-                getScheduleCallback(site, data)
+                getScheduleCallback(site, data);
             }));
         }
     });
@@ -118,8 +118,7 @@ var getScheduleCallback = function(site, data) {
                 eventType = '<i class="fa fa-question-circle fa-lg"></i> Something ';
             }
 
-            dt.utcOffset(moment().utcOffset());
-
+            dt.utcOffset(getUtcOffset());
             if (today == dt) {
                 scheduleDate = dt.fromNow();
             } else {
@@ -226,4 +225,18 @@ var scheduleRoutine = function() {
     });
 
     return getScheduleDone.promise();
+};
+
+/**
+ * Get UTC offset from storage, if set and a number. Otherwise return
+ * automatic value from moment.js.
+ * Used when getting offset for timezone adjustment.
+ */
+var getUtcOffset = function(){
+
+    var storageOffset = storage.get('utc-offset');
+    if(storageOffset == null || isNaN(storageOffset)) {
+        return moment().utcOffset();
+    }
+    return storageOffset;
 };

--- a/js/functions.js
+++ b/js/functions.js
@@ -23,7 +23,8 @@ var preferences = {
     'cv-upcoming': {default: true, type: 'checkbox'},
     'cv-live': {default: true, type: 'checkbox'},
 
-    '24h-clock': {default: false, type: 'checkbox'}
+    '24h-clock': {default: false, type: 'checkbox'},
+    'utc-offset': {default: "auto", type: 'select-one'}
 };
 
 //Initialize audio handler object.

--- a/js/livebomb.js
+++ b/js/livebomb.js
@@ -40,6 +40,19 @@ $(function() {
         });
     };
 
+    /**
+     * Get offset from storage. If value is not set return "auto".
+     * Used when updating the select option to previously stored value.
+     */
+    var getUtcOffsetFromStorage = function(){
+
+        var storageOffset = storage.get('utc-offset');
+        if(storageOffset == null) {
+            return "auto"
+        }
+        return storageOffset;
+    };
+
     var pluralize = function(number, string) {
         return '' + number + string + (number !== 1 ? 's' : '');
     };
@@ -56,6 +69,9 @@ $(function() {
     if (navigator.appVersion.indexOf('Mac') !== -1) {
         $('body').css('border','1.5px solid');
     }
+
+    //select current value utc-offset
+    $("#select-utc-offset").val(getUtcOffsetFromStorage());
 
     //Initialize settings display
     $.each(preferences, function(name, val) {
@@ -85,7 +101,7 @@ $(function() {
     }
 
     //Save Preferences automatically
-    $('input').change(function() {
+    $('input, select').change(function() {
         //Display "Saved" message.
         storage.set('preferences','user-preference');
         cfgMessage.fadeIn(700).fadeTo(350, 1).fadeOut(400);
@@ -98,6 +114,8 @@ $(function() {
             $('body').trigger('checkBadge');
         } else if (this.type == "range") {
             storage.set(this.name, this.value);
+        } else if (this.type == "select-one") {
+            storage.set(this.name, this.options[this.selectedIndex].value);
         }
     });
 

--- a/popup.html
+++ b/popup.html
@@ -69,7 +69,41 @@
                                             </label>
                                         </div>
                                     </div>
-
+                                    <div class="row">
+                                        <div class="col-xs-12">
+                                            <label class="select-one-inline">
+                                                <select id="select-utc-offset" name="utc-offset">
+													<option value="auto">Autodetect</option>
+													<option value="-12">UTC-12</option>
+													<option value="-11">UTC-11</option>
+													<option value="-10">UTC-10</option>
+													<option value="-9">UTC-9</option>
+													<option value="-8">UTC-8</option>
+													<option value="-7">UTC-7</option>
+													<option value="-6">UTC-6</option>
+													<option value="-5">UTC-5</option>
+													<option value="-4">UTC-4</option>
+													<option value="-3">UTC-3</option>
+													<option value="-2">UTC-2</option>
+													<option value="-1">UTC-1</option>
+													<option value="0">UTC</option>
+													<option value="1">UTC+1</option>
+													<option value="2">UTC+2</option>
+													<option value="3">UTC+3</option>
+													<option value="4">UTC+4</option>
+													<option value="5">UTC+5</option>
+													<option value="6">UTC+6</option>
+													<option value="7">UTC+7</option>
+													<option value="8">UTC+8</option>
+													<option value="9">UTC+9</option>
+													<option value="10">UTC+10</option>
+													<option value="11">UTC+11</option>
+													<option value="12">UTC+12</option>
+											</select>
+											<span>UTC offset</span>
+                                            </label>
+                                        </div>
+                                    </div>
                                     <!-- <div class="row">
                                         <div class="col-xs-12">
                                             <h5>GameSpot</h5>


### PR DESCRIPTION
Simple select with options for overriding UTC offset with -12 to 12 (+ one for automatic)

Not sure if this is actually wanted, but it was mentioned in issue #25 . Also not sure it's a good implementation,, keep or trash as you see fit ;) 

Edit: Added update to fix slight problems with 24h clock option. 

Could not find any existing tests, so didn't try to add any for this either.

![image](https://cloud.githubusercontent.com/assets/2851683/24427684/2c0c1e1e-140c-11e7-9620-6bf3b02b80e4.png)  ![image](https://cloud.githubusercontent.com/assets/2851683/24427615/f17f688c-140b-11e7-85e7-54a2d05ba2c9.png)

![image](https://cloud.githubusercontent.com/assets/2851683/24378218/79141560-1342-11e7-9bc5-cf5fa3ba475c.png)

